### PR TITLE
Add Bounded instances for Month and WeekDay

### DIFF
--- a/Data/Hourglass/Types.hs
+++ b/Data/Hourglass/Types.hs
@@ -166,7 +166,7 @@ data Month =
     | October
     | November
     | December
-    deriving (Show,Eq,Ord,Enum,Data,Typeable)
+    deriving (Show,Eq,Ord,Enum,Data,Typeable,Bounded)
 
 -- | Day of the week
 --
@@ -179,7 +179,7 @@ data WeekDay =
     | Thursday
     | Friday
     | Saturday
-    deriving (Show,Read,Eq,Ord,Enum,Data,Typeable)
+    deriving (Show,Read,Eq,Ord,Enum,Data,Typeable,Bounded)
 
 -- | Offset against UTC in minutes
 --


### PR DESCRIPTION
This is convenient for some user interaction stuff, e.g., having a single function that can use `[minBound..maxBound]` across a number of "enums" to spit out all valid options for things, particularly when coupled with Show instances.

There are other types that could potentially have Bounded instances as well (TimeOfDay, TimezoneOffset, etc.), but I don't know if those would be terribly useful (and they aren't just a single word addition) so they are not implemented.

Thoughts?