### PR TITLE
dateAddPeriod fixes

### DIFF
--- a/Data/Hourglass/Diff.hs
+++ b/Data/Hourglass/Diff.hs
@@ -86,6 +86,12 @@ dateAddPeriod (Date yOrig mOrig dOrig) (Period yDiff mDiff dDiff) =
   where
     (yDiffAcc,mStartPos) = (fromEnum mOrig + mDiff) `divMod` 12
     loop y m d
+        | d <= 0 =
+            let (m', y') = if m == 0
+                then (11, y - 1)
+                else (m - 1, y)
+            in
+            loop y' m' (daysInMonth y' (toEnum m') + d)
         | d <= dMonth = Date y (toEnum m) d
         | otherwise  =
             let newDiff = d - dMonth

--- a/Data/Hourglass/Diff.hs
+++ b/Data/Hourglass/Diff.hs
@@ -86,10 +86,10 @@ dateAddPeriod (Date yOrig mOrig dOrig) (Period yDiff mDiff dDiff) =
   where
     (yDiffAcc,mStartPos) = (fromEnum mOrig + mDiff) `divMod` 12
     loop y m d
-        | d < dMonth = Date y (toEnum m) d
+        | d <= dMonth = Date y (toEnum m) d
         | otherwise  =
             let newDiff = d - dMonth
-             in if m == 12
+             in if m == 11
                     then loop (y+1) 0 newDiff
                     else loop y (m+1) newDiff
       where dMonth = daysInMonth y (toEnum m)

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -51,6 +51,15 @@ dateEqual localtime utcTime =
        (h' , mi') = dt' `divMod` 60
        (DateTime (Date y m d) (TimeOfDay h mi sec _)) = localTimeToGlobal localtime
 
+-- | The @Date@ type is able to represent some values that aren't actually legal,
+-- specifically dates with a day field outside of the range of dates in the
+-- month. This function validates a @Date@. It is conservative; it only verifies
+-- that the day is less than 31. TODO: It would be nice to tighten this up a
+-- bit. There's a daysInMonth function we could use for this,
+-- but Data.Hourglass.Calendar, but it isn't exposed.
+isValidDate :: Date -> Bool
+isValidDate (Date _ _ d) = d > 0 && d <= 31
+
 -- windows native functions to convert time cannot handle time before year 1601
 #ifdef WINDOWS
 loElapsed = -11644473600 -- ~ year 1601
@@ -183,6 +192,8 @@ tests knowns = testGroup "hourglass"
                 (toEnum ((fromEnum m+1) `mod` 12) `eq` m')        &&
                 (if m == December then (y+1) `eq` y' else y `eq` y')
                 -}
+        , testProperty "dateAddPeriod" $ (\date period ->
+            isValidDate (date `dateAddPeriod` period))
         ]
     , testGroup "formating"
         [ testProperty "iso8601 date" $ \(e :: Elapsed) ->


### PR DESCRIPTION
I found a couple bugs. The commit messages on the last two commits give examples.

This includes a quickcheck property test, but (1) I'm not really sure it's in a good spot, and (2) per the comment, it would be nice if we could somehow expose daysInMonth, which would let us expand the Arbitrary instance for Period to cover dates with day > 28 (where appropriate).