### PR TITLE
Fix instance of `Real` of `ElapsedP` (#33)

### DIFF
--- a/Time/Types.hs
+++ b/Time/Types.hs
@@ -149,6 +149,8 @@ subElapsedP (ElapsedP e1 (NanoSeconds ns1)) (ElapsedP e2 (NanoSeconds ns2)) =
 
 instance Real ElapsedP where
     -- FIXME
+    toRational (ElapsedP (Elapsed (Seconds s)) (NanoSeconds 0)) =
+        fromIntegral s
     toRational (ElapsedP (Elapsed (Seconds s)) (NanoSeconds ns)) =
         fromIntegral s + (1000000000 % fromIntegral ns)
 

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -224,6 +224,12 @@ tests knowns = testGroup "hourglass"
         , testProperty "custom-1" $ test_property_format ("YYYY-MM-DDTH:MI:S.msusns" :: String)
         , testProperty "custom-2" $ test_property_format ("Mon DD\\t\\h YYYY at HH\\hMI\\mS\\s.p9\\n\\s" :: String)
         ]
+    , testGroup "Regression Tests"
+        [ testCase  "Real instance of ElapsedP (#33)" $
+            let res = toRational (ElapsedP (Elapsed $ Seconds 0) (NanoSeconds 0))
+                ref = toRational 0 :: Rational
+             in assertEqual "failed equality" ref res
+        ]
     ]
   where toCalendarTest (i, (us, dt)) =
             testCase (show i) (dt @=? timeGetDateTimeOfDay us)


### PR DESCRIPTION
Simply wrote a separate case when the `NanoSecond` part of `ElapsedP` is 0.

fix #33
