### PR TITLE
Fix examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ ptime <- timeCurrent
 import Data.Time.Clock
 import Data.Time.Calendar
 
-currentYear <- (\(y,_,_) -> y) . toGregorian . utcDay <$> getCurrentTime
+currentYear <- (\(y,_,_) -> y) . toGregorian . utctDay <$> getCurrentTime
 
 -- With hourglass
 import System.Hourglass
-import Data.Time
+import Data.Hourglass
 
 currentYear <- dateYear . timeGetDate <$> timeCurrent
 ```
@@ -72,14 +72,14 @@ currentYear <- dateYear . timeGetDate <$> timeCurrent
 ```haskell
 -- With time
 import Data.Time.Clock
-import Date.Time.Calendar
+import Data.Time.Calendar
 
 let day = fromGregorian 1970 5 4
     diffTime = secondsToDiffTime (15 * 3600 + 12 * 60 + 24)
 in UTCTime day diffTime
 
 -- With hourglass
-import Date.Time
+import Data.Hourglass
 
 DateTime (Date 1970 May 4) (TimeOfDay 15 12 24 0)
 ```

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ ptime <- timeCurrent
 * Getting the current year:
 ```haskell
 -- With time
-import Data.Time.Clock
-import Data.Time.Calendar
+import Data.Time
 
 currentYear <- (\(y,_,_) -> y) . toGregorian . utctDay <$> getCurrentTime
 
@@ -71,12 +70,9 @@ currentYear <- dateYear . timeGetDate <$> timeCurrent
 * Representating "4th May 1970 15:12:24"
 ```haskell
 -- With time
-import Data.Time.Clock
-import Data.Time.Calendar
+import Data.Time
 
-let day = fromGregorian 1970 5 4
-    diffTime = secondsToDiffTime (15 * 3600 + 12 * 60 + 24)
-in UTCTime day diffTime
+UTCTime (fromGregorian 1970 5 4) (timeOfDayToTime $ TimeOfDay 15 12 24)
 
 -- With hourglass
 import Data.Hourglass


### PR DESCRIPTION
The first commit makes the examples work. The second shows what I believe to be more idiomatic use of `time` for these examples.